### PR TITLE
Inverse the power value for the modbus battery

### DIFF
--- a/drivers/battery_modbus/device.js
+++ b/drivers/battery_modbus/device.js
@@ -23,7 +23,7 @@ class BatteryDevice extends BaseDevice {
 
       this.setCapabilityValue('meter_power.charged', data['0x120'].value),
       this.setCapabilityValue('meter_power.discharged', data['0x122'].value),
-      this.setCapabilityValue('meter_power.grid', data['0x124'].value),
+      this.setCapabilityValue('meter_power.grid', data['0x124'].value * -1),
     ]);
   }
 


### PR DESCRIPTION
The modbus battery shows the value inverted (so charging with 2000 WATT while its actually discharging and vice versa)

Fixes #9 